### PR TITLE
explicitly identify Element for PostgresQueue.AsyncIterator

### DIFF
--- a/Sources/HummingbirdJobsPostgres/PostgresJobsQueue.swift
+++ b/Sources/HummingbirdJobsPostgres/PostgresJobsQueue.swift
@@ -281,6 +281,8 @@ public final class PostgresQueue: JobQueueDriver {
 /// extend PostgresJobQueue to conform to AsyncSequence
 extension PostgresQueue {
     public struct AsyncIterator: AsyncIteratorProtocol {
+        public typealias Element = QueuedJob<JobID>
+
         let queue: PostgresQueue
 
         public func next() async throws -> Element? {


### PR DESCRIPTION
This resolves a compilation issue with Swift6 - a possible regression in the compiler provided by Xcode 16 beta 2 (`swift-driver version: 1.110 Apple Swift version 6.0 (swiftlang-6.0.0.4.52 clang-1600.0.21.1.3)`)

While this compiles fine with Swift 5.10, it appears to fail to infer `Element` for `PostgresQueue.AsyncIterator`. The follow error is what I received using `swift build` with the verson of Swift included in the Xcode 16 beta 2 toolchain:

```
/Users/heckj/src/hummingbird-postgres/Sources/HummingbirdJobsPostgres/PostgresJobsQueue.swift:45:20: error: type 'PostgresQueue' does not conform to protocol 'AsyncSequence'
 43 | /// }
 44 | /// ```
 45 | public final class PostgresQueue: JobQueueDriver {
    |                    `- error: type 'PostgresQueue' does not conform to protocol 'AsyncSequence'
 46 |     public typealias JobID = UUID
 47 |

_Concurrency.AsyncSequence:4:20: note: protocol requires nested type 'Element'; add nested type 'Element' for conformance
2 | public protocol AsyncSequence<Element, Failure> {
3 |     associatedtype AsyncIterator : AsyncIteratorProtocol
4 |     associatedtype Element where Self.Element == Self.AsyncIterator.Element
  |                    `- note: protocol requires nested type 'Element'; add nested type 'Element' for conformance
5 |     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
6 |     associatedtype Failure = Self.AsyncIterator.Failure where Self.Failure == Self.AsyncIterator.Failure
  |                    `- note: protocol requires nested type 'Failure'; add nested type 'Failure' for conformance
7 |     __consuming func makeAsyncIterator() -> Self.AsyncIterator
8 | }
```

This adds an explicit type for AsyncIterator Element, which resolves the compilation issue.