### PR TITLE
chore(atomic): Make Postgres transactions atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@
 
 Hummingbird postgres provides implementations of the job and persist frameworks from Hummingbird and a database migration system all using the `PostgresClient` from PostgresNIO.
 
+## Local Development setup
+
+Setup run
+```sh
+docker compose up
+or 
+docker-compose up
+```
+Tear down
+
+```sh
+docker compose down
+or
+docker-compose down
+```
+
 ## Documentation
 
 Reference documentation and guides for HummingbirdPostgres can be found [here](https://docs.hummingbird.codes/2.0/documentation/hummingbirdpostgres).

--- a/Sources/HummingbirdPostgres/Migration.swift
+++ b/Sources/HummingbirdPostgres/Migration.swift
@@ -18,7 +18,7 @@ import PostgresNIO
 /// Protocol for a database migration
 ///
 /// Requires two functions one to apply the database migration and one to revert it.
-public protocol PostgresMigration: Sendable {
+public protocol PostgresMigration {
     /// Apply database migration
     func apply(connection: PostgresConnection, logger: Logger) async throws
     /// Revert database migration

--- a/Sources/HummingbirdPostgres/Migration.swift
+++ b/Sources/HummingbirdPostgres/Migration.swift
@@ -18,7 +18,7 @@ import PostgresNIO
 /// Protocol for a database migration
 ///
 /// Requires two functions one to apply the database migration and one to revert it.
-public protocol PostgresMigration {
+public protocol PostgresMigration: Sendable {
     /// Apply database migration
     func apply(connection: PostgresConnection, logger: Logger) async throws
     /// Revert database migration
@@ -54,7 +54,7 @@ extension PostgresMigration {
 /// Only use a group different from `.default` if you are certain that the database elements you are
 /// creating within that group will always be independent of everything else in the database. Groups
 /// are useful for libraries that use migrations to setup their database elements.
-public struct PostgresMigrationGroup: Hashable, Equatable {
+public struct PostgresMigrationGroup: Hashable, Equatable, Sendable {
     let name: String
 
     public init(_ name: String) {

--- a/Sources/JobsPostgres/Migrations/CreateJobQueue.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobQueue.swift
@@ -22,7 +22,7 @@ struct CreateJobQueue: PostgresMigration {
             """
             CREATE TABLE IF NOT EXISTS _hb_pg_job_queue (
                 job_id uuid PRIMARY KEY,
-                created_at timestamp with time zone
+                createdAt timestamp with time zone
             )
             """,
             logger: logger
@@ -30,7 +30,7 @@ struct CreateJobQueue: PostgresMigration {
         try await connection.query(
             """
             CREATE INDEX IF NOT EXISTS _hb_job_queueidx 
-            ON _hb_pg_job_queue(created_at ASC)
+            ON _hb_pg_job_queue(createdAt ASC)
             """,
             logger: logger
         )

--- a/Sources/JobsPostgres/Migrations/CreateJobQueue.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobQueue.swift
@@ -22,7 +22,7 @@ struct CreateJobQueue: PostgresMigration {
             """
             CREATE TABLE IF NOT EXISTS _hb_pg_job_queue (
                 job_id uuid PRIMARY KEY,
-                createdAt timestamp with time zone
+                created_at timestamp with time zone
             )
             """,
             logger: logger
@@ -30,7 +30,7 @@ struct CreateJobQueue: PostgresMigration {
         try await connection.query(
             """
             CREATE INDEX IF NOT EXISTS _hb_job_queueidx 
-            ON _hb_pg_job_queue (createdAt ASC)
+            ON _hb_pg_job_queue(created_at ASC)
             """,
             logger: logger
         )

--- a/Sources/JobsPostgres/Migrations/CreateJobs.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobs.swift
@@ -24,7 +24,7 @@ struct CreateJobs: PostgresMigration {
                 id uuid PRIMARY KEY,
                 job bytea,
                 status smallint,
-                last_modified TIMESTAMPTZ DEFAULT NOW()
+                lastModified TIMESTAMPTZ DEFAULT NOW()
             )     
             """,
             logger: logger

--- a/Sources/JobsPostgres/Migrations/CreateJobs.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobs.swift
@@ -29,7 +29,7 @@ struct CreateJobs: PostgresMigration {
             """,
             logger: logger
         )
-        
+
         try await connection.query(
             """
             CREATE INDEX IF NOT EXISTS _hb_job_status

--- a/Sources/JobsPostgres/Migrations/CreateJobs.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobs.swift
@@ -29,7 +29,6 @@ struct CreateJobs: PostgresMigration {
             """,
             logger: logger
         )
-
         try await connection.query(
             """
             CREATE INDEX IF NOT EXISTS _hb_job_status

--- a/Sources/JobsPostgres/Migrations/CreateJobs.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobs.swift
@@ -24,8 +24,16 @@ struct CreateJobs: PostgresMigration {
                 id uuid PRIMARY KEY,
                 job bytea,
                 status smallint,
-                lastModified TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                last_modified TIMESTAMPTZ DEFAULT NOW()
             )     
+            """,
+            logger: logger
+        )
+        
+        try await connection.query(
+            """
+            CREATE INDEX IF NOT EXISTS _hb_job_status
+            ON _hb_pg_jobs(status)
             """,
             logger: logger
         )

--- a/Sources/JobsPostgres/PostgresClient+Transaction.swift
+++ b/Sources/JobsPostgres/PostgresClient+Transaction.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PostgresNIO
+
+extension PostgresClient {
+    func withTransaction<Value>(logger: Logger, _ process: (PostgresConnection) async throws -> Value) async throws -> Value {
+        try await withConnection { connection in
+            do {
+                try await connection.query("BEGIN;", logger: logger)
+                let value = try await process(connection)
+                try await connection.query("COMMIT;", logger: logger)
+                return value
+            } catch {
+                try await connection.query("ROLLBACK;", logger: logger)
+                throw error
+            }
+        }
+    }
+}

--- a/Sources/JobsPostgres/PostgresJobsQueue.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue.swift
@@ -134,8 +134,10 @@ public final class PostgresJobQueue: JobQueueDriver {
     @discardableResult public func push(_ buffer: ByteBuffer) async throws -> JobID {
         try await self.client.withConnection { connection in
             let queuedJob = QueuedJob<JobID>(id: .init(), jobBuffer: buffer)
-            try await add(queuedJob, connection: connection)
-            try await addToQueue(jobId: queuedJob.id, connection: connection)
+            try await self.startTransaction(connection: connection)
+            try await self.add(queuedJob, connection: connection)
+            try await self.addToQueue(jobId: queuedJob.id, connection: connection)
+            try await self.commitTransaction(connection: connection)
             return queuedJob.id
         }
     }
@@ -163,6 +165,7 @@ public final class PostgresJobQueue: JobQueueDriver {
             return try await self.client.withConnection { connection -> QueuedJob? in
                 while true {
                     try Task.checkCancellation()
+                    try await self.startTransaction(connection: connection)
                     let stream = try await connection.query(
                         """
                         DELETE
@@ -170,7 +173,7 @@ public final class PostgresJobQueue: JobQueueDriver {
                         WHERE pse.job_id =
                             (SELECT pse_inner.job_id
                             FROM _hb_pg_job_queue pse_inner
-                            ORDER BY pse_inner.createdAt ASC
+                            ORDER BY pse_inner.created_at ASC
                                 FOR UPDATE SKIP LOCKED
                             LIMIT 1)
                         RETURNING pse.job_id
@@ -179,11 +182,12 @@ public final class PostgresJobQueue: JobQueueDriver {
                     )
                     // return nil if nothing in queue
                     guard let jobId = try await stream.decode(UUID.self, context: .default).first(where: { _ in true }) else {
+                        try await self.commitTransaction(connection: connection)
                         return nil
                     }
                     // select job from job table
                     let stream2 = try await connection.query(
-                        "SELECT job FROM _hb_pg_jobs WHERE id = \(jobId)",
+                        "SELECT job FROM _hb_pg_jobs WHERE id = \(jobId) FOR UPDATE SKIP LOCKED",
                         logger: self.logger
                     )
 
@@ -193,9 +197,11 @@ public final class PostgresJobQueue: JobQueueDriver {
                         guard let buffer = try await stream2.decode(ByteBuffer.self, context: .default).first(where: { _ in true }) else {
                             continue
                         }
+                        try await self.commitTransaction(connection: connection)
                         return QueuedJob(id: jobId, jobBuffer: buffer)
                     } catch {
                         try await self.setStatus(jobId: jobId, status: .failed, connection: connection)
+                        try await self.rollbackTransaction(connection: connection)
                         throw JobQueueError.decodeJobFailed
                     }
                 }
@@ -226,7 +232,7 @@ public final class PostgresJobQueue: JobQueueDriver {
     func addToQueue(jobId: JobID, connection: PostgresConnection) async throws {
         try await connection.query(
             """
-            INSERT INTO _hb_pg_job_queue (job_id, createdAt) VALUES (\(jobId), \(Date.now))
+            INSERT INTO _hb_pg_job_queue (job_id, created_at) VALUES (\(jobId), \(Date.now))
             """,
             logger: self.logger
         )
@@ -234,21 +240,21 @@ public final class PostgresJobQueue: JobQueueDriver {
 
     func setStatus(jobId: JobID, status: Status, connection: PostgresConnection) async throws {
         try await connection.query(
-            "UPDATE _hb_pg_jobs SET status = \(status), lastModified = \(Date.now) WHERE id = \(jobId)",
+            "UPDATE _hb_pg_jobs SET status = \(status), last_modified = \(Date.now) WHERE id = \(jobId)",
             logger: self.logger
         )
     }
 
     func setStatus(jobId: JobID, status: Status) async throws {
         try await self.client.query(
-            "UPDATE _hb_pg_jobs SET status = \(status), lastModified = \(Date.now) WHERE id = \(jobId)",
+            "UPDATE _hb_pg_jobs SET status = \(status), last_modified = \(Date.now) WHERE id = \(jobId)",
             logger: self.logger
         )
     }
 
     func getJobs(withStatus status: Status) async throws -> [JobID] {
         let stream = try await self.client.query(
-            "SELECT id FROM _hb_pg_jobs WHERE status = \(status)",
+            "SELECT id FROM _hb_pg_jobs WHERE status = \(status) FOR UPDATE SKIP LOCKED",
             logger: self.logger
         )
         var jobs: [JobID] = []
@@ -262,16 +268,18 @@ public final class PostgresJobQueue: JobQueueDriver {
         switch onInit {
         case .remove:
             try await connection.query(
-                "DELETE FROM _hb_pg_jobs WHERE status = \(status)",
+                "DELETE FROM _hb_pg_jobs WHERE status = \(status) ",
                 logger: self.logger
             )
         case .rerun:
             guard status != .pending else { return }
+            try await self.startTransaction(connection: connection)
             let jobs = try await getJobs(withStatus: status)
             self.logger.info("Moving \(jobs.count) jobs with status: \(status) to job queue")
             for jobId in jobs {
                 try await self.addToQueue(jobId: jobId, connection: connection)
             }
+            try await self.commitTransaction(connection: connection)
         case .doNothing:
             break
         }
@@ -301,6 +309,18 @@ extension PostgresJobQueue {
 
     public func makeAsyncIterator() -> AsyncIterator {
         return .init(queue: self)
+    }
+
+    private func startTransaction(connection: PostgresConnection) async throws {
+        try await connection.query("BEGIN;", logger: self.logger)
+    }
+
+    private func commitTransaction(connection: PostgresConnection) async throws {
+        try await connection.query("COMMIT;", logger: self.logger)
+    }
+
+    private func rollbackTransaction(connection: PostgresConnection) async throws {
+        try await connection.query("ROLLBACK;", logger: self.logger)
     }
 }
 

--- a/Tests/HummingbirdPostgresTests/MigrationTests.swift
+++ b/Tests/HummingbirdPostgresTests/MigrationTests.swift
@@ -20,7 +20,7 @@ final class MigrationTests: XCTestCase {
             }
         }
 
-        internal init(
+        init(
             name: String,
             order: Order = Order(),
             applyOrder: Int? = nil,

--- a/Tests/HummingbirdPostgresTests/TestUtils.swift
+++ b/Tests/HummingbirdPostgresTests/TestUtils.swift
@@ -6,10 +6,10 @@ func getPostgresConfiguration() async throws -> PostgresClient.Configuration {
     let env = try await Environment().merging(with: .dotEnv())
     return .init(
         host: env.get("POSTGRES_HOSTNAME") ?? "localhost",
-        port: env.get("POSTGRES_PORT", as: Int.self) ?? 5432,
-        username: env.get("POSTGRES_USER") ?? "test_user",
-        password: env.get("POSTGRES_PASSWORD") ?? "test_pasword",
-        database: env.get("POSTGRES_DB") ?? "test_db",
+        port: env.get("POSTGRES_PORT", as: Int.self) ?? 5434,
+        username: env.get("POSTGRES_USER") ?? "hummingbird",
+        password: env.get("POSTGRES_PASSWORD") ?? "hummingbird",
+        database: env.get("POSTGRES_DB") ?? "hummingbird",
         tls: .disable
     )
 }

--- a/Tests/HummingbirdPostgresTests/TestUtils.swift
+++ b/Tests/HummingbirdPostgresTests/TestUtils.swift
@@ -6,10 +6,10 @@ func getPostgresConfiguration() async throws -> PostgresClient.Configuration {
     let env = try await Environment().merging(with: .dotEnv())
     return .init(
         host: env.get("POSTGRES_HOSTNAME") ?? "localhost",
-        port: env.get("POSTGRES_PORT", as: Int.self) ?? 5434,
-        username: env.get("POSTGRES_USER") ?? "hummingbird",
-        password: env.get("POSTGRES_PASSWORD") ?? "hummingbird",
-        database: env.get("POSTGRES_DB") ?? "hummingbird",
+        port: env.get("POSTGRES_PORT", as: Int.self) ?? 5432,
+        username: env.get("POSTGRES_USER") ?? "test_user",
+        password: env.get("POSTGRES_PASSWORD") ?? "test_password",
+        database: env.get("POSTGRES_DB") ?? "test_db",
         tls: .disable
     )
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - 5434:5432
+    volumes:
+      - db:/var/lib/postgresql/hummingbird
+    environment:
+      - POSTGRES_PASSWORD=hummingbird
+      - POSTGRES_USER=hummingbird
+      - POSTGRES_DB=hummingbird
+volumes:
+  db:
+    driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,16 +1,16 @@
-version: '3.9'
+version: "3.9"
 
 services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - 5434:5432
+      - 5432:5432
     volumes:
       - db:/var/lib/postgresql/hummingbird
     environment:
-      - POSTGRES_PASSWORD=hummingbird
-      - POSTGRES_USER=hummingbird
-      - POSTGRES_DB=hummingbird
+      - POSTGRES_PASSWORD=test_pasword
+      - POSTGRES_USER=test_user
+      - POSTGRES_DB=test_db
 volumes:
   db:
     driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - db:/var/lib/postgresql/hummingbird
     environment:
-      - POSTGRES_PASSWORD=test_pasword
+      - POSTGRES_PASSWORD=test_password
       - POSTGRES_USER=test_user
       - POSTGRES_DB=test_db
 volumes:


### PR DESCRIPTION
Previously, jobs would get queued. They would never get processed until the server is restarted.
This is PR fixes this behavior with transactions and Postgres `FOR UPDATE SKIP LOCKED` [Doc](https://www.postgresql.org/docs/current/sql-select.html)

This PR was tested on Postgres 16 with swift 6.