### PR TITLE
Don't update expires in `set` if it is nil

### DIFF
--- a/Tests/HummingbirdPostgresTests/PersistTests.swift
+++ b/Tests/HummingbirdPostgresTests/PersistTests.swift
@@ -228,12 +228,12 @@ final class PersistTests: XCTestCase {
         try await app.test(.router) { client in
 
             let tag = UUID().uuidString
-            try await client.execute(uri: "/persist/\(tag)/0", method: .put, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { _ in }
+            try await client.execute(uri: "/persist/\(tag)/0", method: .put, body: ByteBuffer(string: "ThisIsTest1")) { _ in }
             try await Task.sleep(nanoseconds: 1_000_000_000)
             try await client.execute(uri: "/persist/\(tag)", method: .get) { response in
                 XCTAssertEqual(response.status, .noContent)
             }
-            try await client.execute(uri: "/persist/\(tag)/10", method: .put, body: ByteBufferAllocator().buffer(string: "ThisIsTest1")) { response in
+            try await client.execute(uri: "/persist/\(tag)/10", method: .put, body: ByteBuffer(string: "ThisIsTest1")) { response in
                 XCTAssertEqual(response.status, .ok)
             }
             try await client.execute(uri: "/persist/\(tag)", method: .get) { response in


### PR DESCRIPTION
In PostgresPersistDriver.set if expires is `nil` and a value for this key already exists then don't update the expiration date 