### PR TITLE
Persist invalid conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "PostgresMigrations", targets: ["PostgresMigrations"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.5.0"),
         .package(url: "https://github.com/vapor/postgres-nio", from: "1.21.0"),
     ],
     targets: [

--- a/Tests/HummingbirdPostgresTests/PersistTests.swift
+++ b/Tests/HummingbirdPostgresTests/PersistTests.swift
@@ -211,6 +211,31 @@ final class PersistTests: XCTestCase {
         }
     }
 
+    func testInvalidGetAs() async throws {
+        struct TestCodable: Codable {
+            let buffer: String
+        }
+        let app = try await Self.createApplication { router, persist in
+            router.put("/invalid") { _, _ -> HTTPResponse.Status in
+                try await persist.set(key: "test", value: TestCodable(buffer: "hello"))
+                return .ok
+            }
+            router.get("/invalid") { _, _ -> String? in
+                do {
+                    return try await persist.get(key: "test", as: String.self)
+                } catch let error as PersistError where error == .invalidConversion {
+                    throw HTTPError(.badRequest)
+                }
+            }
+        }
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/invalid", method: .put)
+            try await client.execute(uri: "/invalid", method: .get) { response in
+                XCTAssertEqual(response.status, .badRequest)
+            }
+        }
+    }
+
     func testRemove() async throws {
         let app = try await Self.createApplication()
         try await app.test(.router) { client in


### PR DESCRIPTION
Throw `PersistError.invalidConversion` when failing to convert in `PostgresPersistDriver.get(key:as:)`