### PR TITLE
Don't revert migrations that are no longer in the list of migrations to apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,14 @@ on:
   push:
     branches:
     - main
-    - 2.x.x
     paths:
     - '**.swift'
     - '**.yml'
   pull_request:
-    branches:
-    - main
-    - 2.x.x
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-ci
+  cancel-in-progress: true
 
 jobs:
 #  macOS:
@@ -41,17 +40,18 @@ jobs:
         image:
           - 'swift:5.9'
           - 'swift:5.10'
+          - 'swift:6.0'
         postgres-image:
+          - 'postgres:17'
           - 'postgres:16'
           - 'postgres:14'
-          - 'postgres:12'
         include:
+          - postgres-image: postgres:17
+            postgres-auth: scram-sha-256
           - postgres-image: postgres:16
             postgres-auth: scram-sha-256
           - postgres-image: postgres:14
             postgres-auth: md5
-          - postgres-image: postgres:12
-            postgres-auth: trust
     container:
       image: ${{ matrix.image }}
       volumes: [ 'pgrunshare:/var/run/postgresql' ]
@@ -88,4 +88,5 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v5
       with:
-        file: info.lcov
+        files: info.lcov
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/Sources/PostgresMigrations/MigrationError.swift
+++ b/Sources/PostgresMigrations/MigrationError.swift
@@ -17,6 +17,7 @@ public struct DatabaseMigrationError: Error, Equatable {
     enum _Internal {
         case dupicateNames
         case requiresChanges
+        case appliedMigrationsInconsistent
         case cannotRevertMigration
     }
 
@@ -30,6 +31,8 @@ public struct DatabaseMigrationError: Error, Equatable {
     public static var dupicateNames: Self { .init(.dupicateNames) }
     /// The database requires a migration before the application can run
     public static var requiresChanges: Self { .init(.requiresChanges) }
+    /// Applied migrations are inconsistent with expected list
+    public static var appliedMigrationsInconsistent: Self { .init(.appliedMigrationsInconsistent) }
     /// Cannot revert a migration as we do not have its details. Add it to the revert list using
     /// PostgresMigrations.add(revert:)
     public static var cannotRevertMigration: Self { .init(.cannotRevertMigration) }
@@ -40,6 +43,7 @@ extension DatabaseMigrationError: CustomStringConvertible {
         switch self.value {
         case .dupicateNames: "The migration list has duplicate names in it."
         case .requiresChanges: "Database requires changes. Run `migrate` with `dryRun` set to false."
+        case .appliedMigrationsInconsistent: "Applied migrations are inconsistent with expected list."
         case .cannotRevertMigration:
             "Cannot revert migration because we don't have its details. Use `PostgresMigrations.register` to register the DatabaseMigration."
         }

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -51,15 +51,8 @@ public actor DatabaseMigrations {
     /// Apply database migrations
     ///
     /// This function compares the list of applied migrations and the list of desired migrations. If there
-    /// are migrations in the applied list that don't exist in the desired list then every migration after
-    /// the missing migration is reverted. Then every unapplied migration from the desired list is applied.
-    ///
-    /// This means removing a single migration from the desired list will revert every migration after the
-    /// removed migation, changing the order will revert the moved migrations and any migration after.
-    ///
-    /// As migrating can be a destructive process it is best to run this with `dryRun`` set to true by default
-    /// and only run it properly if an error is thrown to indicate a migration is required. But check the list
-    /// of reported migrations and reverts before doing this though.
+    /// are migrations in the applied list that don't exist in the desired list or the order of migrations
+    /// is different in the applied list then an error is thrown.
     ///
     /// - Parameters:
     ///   - client: Postgres client
@@ -75,62 +68,15 @@ public actor DatabaseMigrations {
         try checkForDuplicates(logger: logger)
         // wait a small period to ensure the PostgresClient has started up
         try await Task.sleep(for: .microseconds(100))
-        try await self.migrate(
-            client: client,
-            migrations: self.migrations,
-            groups: groups,
-            logger: logger,
-            completeMigrations: true,
-            dryRun: dryRun
-        )
-    }
-
-    /// Revert database migrations
-    /// - Parameters:
-    ///   - client: Postgres client
-    ///   - groups: Migration groups to revert, an empty array means all groups
-    ///   - logger: Logger to use
-    ///   - dryRun: Should migrations actually be reverted, or should we just report what would be reverted
-    public func revert(
-        client: PostgresClient,
-        groups: [DatabaseMigrationGroup] = [],
-        logger: Logger,
-        dryRun: Bool
-    ) async throws {
-        try await self.migrate(
-            client: client,
-            migrations: [],
-            groups: groups,
-            logger: logger,
-            completeMigrations: false,
-            dryRun: dryRun
-        )
-    }
-
-    private func migrate(
-        client: PostgresClient,
-        migrations: [DatabaseMigration],
-        groups: [DatabaseMigrationGroup],
-        logger: Logger,
-        completeMigrations: Bool,
-        dryRun: Bool
-    ) async throws {
         switch self.state {
         case .completed, .failed:
             self.state = .waiting([])
         case .waiting:
             break
         }
+        let migrations = self.migrations
         let repository = PostgresMigrationRepository(client: client)
         do {
-            // build map of registered migrations
-            let registeredMigrations = {
-                var registeredMigrations = self.reverts
-                for migration in self.migrations {
-                    registeredMigrations[migration.name] = migration
-                }
-                return registeredMigrations
-            }()
             _ = try await repository.withContext(logger: logger) { context in
                 // setup migration repository (create table)
                 try await repository.setup(context: context)
@@ -156,27 +102,12 @@ public actor DatabaseMigrations {
                     {
                         i += 1
                     }
-                    // Revert deleted migrations, and any migrations after a deleted migration
-                    for j in (i..<appliedGroupMigrations.count).reversed() {
-                        let migrationName = appliedGroupMigrations[j].name
-                        // look for migration to revert in registered migration list and revert dictionary.
-                        guard let migration = registeredMigrations[migrationName]
-                        else {
-                            logger.error("Failed to find migration \(migrationName)")
-                            throw DatabaseMigrationError.cannotRevertMigration
-                        }
-                        logger.info("Reverting \(migrationName) from group \(group.name) \(dryRun ? " (dry run)" : "")")
-                        if !dryRun {
-                            try await migration.revert(
-                                connection: context.connection,
-                                logger: context.logger
-                            )
-                            try await repository.remove(migration, context: context)
-                        } else {
-                            requiresChanges = true
-                        }
+                    guard i == appliedGroupMigrations.count else {
+                        logger.error("Applied migrations in \(group.name) group are inconsistent with migration list")
+                        printMigrationComparison(expected: groupMigrations.map(\.name), applied: appliedGroupMigrations.map(\.name), logger: logger)
+                        throw DatabaseMigrationError.appliedMigrationsInconsistent
                     }
-                    // Apply migration
+                    // Apply migrations that have not been applied
                     for j in i..<groupMigrations.count {
                         let migration = groupMigrations[j]
                         logger.info(
@@ -202,8 +133,167 @@ public actor DatabaseMigrations {
             self.setFailed(error)
             throw error
         }
-        if completeMigrations {
-            self.setCompleted()
+        self.setCompleted()
+    }
+
+    /// Revert database migrations
+    ///
+    /// This will revert all the migrations in the applied migration list
+    /// - Parameters:
+    ///   - client: Postgres client
+    ///   - groups: Migration groups to revert, an empty array means all groups
+    ///   - logger: Logger to use
+    ///   - dryRun: Should migrations actually be reverted, or should we just report what would be reverted
+    public func revert(
+        client: PostgresClient,
+        groups: [DatabaseMigrationGroup] = [],
+        logger: Logger,
+        dryRun: Bool
+    ) async throws {
+        let repository = PostgresMigrationRepository(client: client)
+        do {
+            let migrations = self.migrations
+            // build map of registered migrations
+            let registeredMigrations = {
+                var registeredMigrations = self.reverts
+                for migration in migrations {
+                    registeredMigrations[migration.name] = migration
+                }
+                return registeredMigrations
+            }()
+            _ = try await repository.withContext(logger: logger) { context in
+                // setup migration repository (create table)
+                try await repository.setup(context: context)
+                var requiresChanges = false
+                // get migrations currently applied in the order they were applied
+                let appliedMigrations = try await repository.getAll(context: context)
+                // if groups array passed in is empty then work out list of migration groups by combining
+                // list of groups from migrations and applied migrations
+                let groups =
+                    groups.count == 0
+                    ? (migrations.map(\.group) + appliedMigrations.map(\.group)).uniqueElements
+                    : groups
+                // for each group revert migrations
+                for group in groups {
+                    let appliedGroupMigrations = appliedMigrations.filter { $0.group == group }
+                    // Revert migrations in reverse
+                    for j in (0..<appliedGroupMigrations.count).reversed() {
+                        let migrationName = appliedGroupMigrations[j].name
+                        // look for migration to revert in registered migration list and revert dictionary.
+                        guard let migration = registeredMigrations[migrationName]
+                        else {
+                            logger.error("Failed to find migration \(migrationName)")
+                            throw DatabaseMigrationError.cannotRevertMigration
+                        }
+                        logger.info("Reverting \(migrationName) from group \(group.name) \(dryRun ? " (dry run)" : "")")
+                        if !dryRun {
+                            try await migration.revert(
+                                connection: context.connection,
+                                logger: context.logger
+                            )
+                            try await repository.remove(migration, context: context)
+                        } else {
+                            requiresChanges = true
+                        }
+                    }
+                }
+                // if changes are required
+                guard requiresChanges == false else {
+                    throw DatabaseMigrationError.requiresChanges
+                }
+            }
+        } catch {
+            self.setFailed(error)
+            throw error
+        }
+    }
+
+    /// Revert database migrations that are inconsistent with the migration list
+    ///
+    /// This will revert any migrations in the applied migration list after an inconsistency has been found in
+    /// list eg a migration is missing or the order of migrations has changed. This is a destructive action
+    /// so it is best to run this with dryRun set to true before running it without so you know what migrations
+    /// it will revert.
+    ///
+    /// For a migration to be removed it has to have been registered either using ``DatabaseMigrations.apply(_:)``
+    /// or ``DatabaseMigrations.register(_:)``.
+    ///
+    /// - Parameters:
+    ///   - client: Postgres client
+    ///   - groups: Migration groups to revert, an empty array means all groups
+    ///   - logger: Logger to use
+    ///   - dryRun: Should migrations actually be reverted, or should we just report what would be reverted
+    public func revertInconsistent(
+        client: PostgresClient,
+        groups: [DatabaseMigrationGroup] = [],
+        logger: Logger,
+        dryRun: Bool
+    ) async throws {
+        let repository = PostgresMigrationRepository(client: client)
+        do {
+            let migrations = self.migrations
+            // build map of registered migrations
+            let registeredMigrations = {
+                var registeredMigrations = self.reverts
+                for migration in migrations {
+                    registeredMigrations[migration.name] = migration
+                }
+                return registeredMigrations
+            }()
+            _ = try await repository.withContext(logger: logger) { context in
+                // setup migration repository (create table)
+                try await repository.setup(context: context)
+                var requiresChanges = false
+                // get migrations currently applied in the order they were applied
+                let appliedMigrations = try await repository.getAll(context: context)
+                // if groups array passed in is empty then work out list of migration groups by combining
+                // list of groups from migrations and applied migrations
+                let groups =
+                    groups.count == 0
+                    ? (migrations.map(\.group) + appliedMigrations.map(\.group)).uniqueElements
+                    : groups
+                // for each group revert migrations
+                for group in groups {
+                    let groupMigrations = migrations.filter { $0.group == group }
+                    let appliedGroupMigrations = appliedMigrations.filter { $0.group == group }
+
+                    let minMigrationCount = min(groupMigrations.count, appliedGroupMigrations.count)
+                    var i = 0
+                    // while migrations and applied migrations are the same
+                    while i < minMigrationCount,
+                        appliedGroupMigrations[i].name == groupMigrations[i].name
+                    {
+                        i += 1
+                    }
+                    // Revert migrations in reverse
+                    for j in (i..<appliedGroupMigrations.count).reversed() {
+                        let migrationName = appliedGroupMigrations[j].name
+                        // look for migration to revert in registered migration list and revert dictionary.
+                        guard let migration = registeredMigrations[migrationName]
+                        else {
+                            logger.error("Failed to find migration \(migrationName)")
+                            throw DatabaseMigrationError.cannotRevertMigration
+                        }
+                        logger.info("Reverting \(migrationName) from group \(group.name) \(dryRun ? " (dry run)" : "")")
+                        if !dryRun {
+                            try await migration.revert(
+                                connection: context.connection,
+                                logger: context.logger
+                            )
+                            try await repository.remove(migration, context: context)
+                        } else {
+                            requiresChanges = true
+                        }
+                    }
+                }
+                // if changes are required
+                guard requiresChanges == false else {
+                    throw DatabaseMigrationError.requiresChanges
+                }
+            }
+        } catch {
+            self.setFailed(error)
+            throw error
         }
     }
 
@@ -271,6 +361,35 @@ public actor DatabaseMigrations {
             throw DatabaseMigrationError.dupicateNames
         }
     }
+
+    nonisolated func printMigrationComparison(expected expectedList: [String], applied appliedList: [String], logger: Logger) {
+        let maxLength = max((expectedList.max { $0.count > $1.count }?.count ?? 0) + 4, 13)
+        func printLine(expected: String, applied: String) {
+            let gap = String(repeating: " ", count: maxLength - expected.count)
+            logger.error("\(expected)\(gap)\(applied)")
+        }
+
+        var expectedIndex = 0
+        var appliedIndex = 0
+        printLine(expected: "Expected:", applied: "Applied:")
+        while true {
+            let expected = expectedIndex < expectedList.count ? expectedList[expectedIndex] : ""
+            var applied = appliedIndex < appliedList.count ? appliedList[appliedIndex] : ""
+
+            if expected == "" && applied == "" {
+                break
+            }
+            if applied != "" {
+                if expected != applied {
+                    applied += " ❌"
+                }
+            }
+            printLine(expected: expected, applied: applied)
+
+            expectedIndex += 1
+            appliedIndex += 1
+        }
+    }
 }
 
 /// Create, remove and list migrations
@@ -282,7 +401,11 @@ struct PostgresMigrationRepository: Sendable {
 
     let client: PostgresClient
 
-    func withContext<Value: Sendable>(logger: Logger, _ process: @Sendable (Context) async throws -> Value) async throws -> Value {
+    func withContext<Value: Sendable>(
+        logger: Logger,
+        isolation: isolated (any Actor)? = #isolation,
+        _ process: sending (Context) async throws -> Value
+    ) async throws -> Value {
         try await self.client.withConnection { connection in
             try await process(.init(connection: connection, logger: logger))
         }


### PR DESCRIPTION
Up to this point when running a migration it would remove any migrations found after an inconsistency was found in the list of migrations. This is far too aggressive and could lead to lost data. Instead in this PR we throw an error if an inconsistency is found and provide a list to compare the migrations setup in the application and the list of applied migrations.

To remove migrations added during development a new function `DatabaseMigrations.revertInconsistent()` has been added. This will revert any migration found after an inconsistency in the lists.