### PR TITLE
Add `checkForDuplicates` parameter to DatabaseMigrations.add()

### DIFF
--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -35,7 +35,9 @@ public actor DatabaseMigrations {
     }
 
     /// Add migration to list of migrations to be be applied
-    /// - Parameter migration: DatabaseMigration to be applied
+    /// - Parameters
+    ///   - migration: DatabaseMigration to be applied
+    ///   - checkForDuplicates: Only add migration if it doesn't exist in the list
     public func add(_ migration: DatabaseMigration, checkForDuplicates: Bool = false) {
         if checkForDuplicates {
             let existingMigration = self.migrations.first {

--- a/Sources/PostgresMigrations/Migrations.swift
+++ b/Sources/PostgresMigrations/Migrations.swift
@@ -36,7 +36,13 @@ public actor DatabaseMigrations {
 
     /// Add migration to list of migrations to be be applied
     /// - Parameter migration: DatabaseMigration to be applied
-    public func add(_ migration: DatabaseMigration) {
+    public func add(_ migration: DatabaseMigration, checkForDuplicates: Bool = false) {
+        if checkForDuplicates {
+            let existingMigration = self.migrations.first {
+                type(of: $0) == type(of: migration)
+            }
+            guard existingMigration == nil else { return }
+        }
         self.migrations.append(migration)
     }
 
@@ -45,6 +51,7 @@ public actor DatabaseMigrations {
     /// This is useful for migrations you might have to revert.
     /// - Parameter migration: DatabaseMigration to be registerd
     public func register(_ migration: DatabaseMigration) {
+
         self.reverts[migration.name] = migration
     }
 


### PR DESCRIPTION
This allows us to call DatabaseMigrations.add() multiple times with the same Migration without worrying about adding it to the list multiple times. I haven't defaulted this action to true because projects with 100s of migrations will end up doing exponential amount of work verifying this.